### PR TITLE
chore: pretty format output configMap

### DIFF
--- a/pkg/hierarchy.go
+++ b/pkg/hierarchy.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -93,7 +94,7 @@ func (config Config) GeneratePropertiesFile(resources []Resource) string {
 		}
 	}
 
-	return properties
+	return strings.TrimSpace(properties)
 }
 
 func (config Config) GenerateJsPropertiesFile(resources []Resource) string {


### PR DESCRIPTION
When drafting the blog/tutorial @flanksaul found that when the controller output is set to file... the created configMap is not pretty formatted.. resulting in 
```
apiVersion: v1
data:
  application.properties: "#\\n# ConfigMap/global\\n#\\nvariableTwo=${variableOne}-globalValueTwo\n#\\n#
    Secret/global\\n#\\nUSER_NAME=admin\n#\\n# ConfigMap/environment\\n#\\nvariableOne=environmentValueOne\nvariableThree=${variableTwo}-environmentValueThree\n#\\n#
    Secret/konfig-manager-tutorial\\n#\\nPASSWORD=thisisapassword\n#\\n# ConfigMap/konfig-manager-tutorial[application.properties]\\n#\\nvariableFour=${variableThree}-applicationValueFour
    \n"
kind: ConfigMap
```

On looking for resolution for the same, found this comment which did the trick in our case as well https://github.com/kubernetes/kubernetes/issues/36222#issuecomment-422056768
creating output:
```
apiVersion: v1
data:
  application.properties: |-
    #
    # ConfigMap/global
    #
    variableTwo=${variableOne}-globalValueTwo
    #
    # Secret/global
    #
    USER_NAME=admin
    #
    # ConfigMap/environment
    #
    variableOne=environmentValueOne
    variableThree=${variableTwo}-environmentValueThree
    #
    # Secret/konfig-manager-tutorial
    #
    PASSWORD=thisisapassword
    #
    # ConfigMap/konfig-manager-tutorial[application.properties]
    #
    variableFour=${variableThree}-applicationValueFour
kind: ConfigMap
```