### PR TITLE
chore: meaningful message in case key is not found in propertiesFile …

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -100,5 +100,4 @@ func init() {
 	GenerateCmd.Flags().StringVarP(&outputType, "output-type", "", "stdout", "type of output: can be one of 'stdout', 'file'")
 	GenerateCmd.Flags().StringVarP(&outputFileType, "output-filetype", "", "env", "when output is a file: can be one of 'env', 'js/javascript'")
 	GenerateCmd.Flags().StringVarP(&output, "output-path", "", "properties/{{.name}}.properties", "output path")
-
 }

--- a/controllers/output.go
+++ b/controllers/output.go
@@ -96,7 +96,6 @@ func (r *KonfigReconciler) getResources(config pkg.Config) ([]pkg.Resource, erro
 		if obj != nil {
 			resources = append(resources, pkg.Resource{Item: obj})
 		}
-
 	}
 	return resources, nil
 }

--- a/pkg/resources.go
+++ b/pkg/resources.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/flanksource/commons/logger"
+
 	"github.com/flanksource/kommons/kustomize"
 	"github.com/hairyhenderson/gomplate/v3/base64"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -77,11 +79,16 @@ func (r Resource) GetPropertiesMap() map[string]string {
 func (r Resource) GeneratePropertesMapFromProperties() map[string]string {
 	var propertiesMap = make(map[string]string)
 	var prop string
+	value := r.Item.Object["data"].(map[string]interface{})[r.Hierarchy.Key]
+	if value == nil {
+		logger.Debugf("can not find the given key: %v in the %v: %v", r.Hierarchy.Key, r.Item.GetKind(), r.Item.GetName())
+		return nil
+	}
 	if r.Item.GetKind() == "Secret" {
-		val, _ := base64.Decode(r.Item.Object["data"].(map[string]interface{})[r.Hierarchy.Key].(string))
+		val, _ := base64.Decode(value.(string))
 		prop = string(val)
 	} else {
-		prop = r.Item.Object["data"].(map[string]interface{})[r.Hierarchy.Key].(string)
+		prop = value.(string)
 	}
 	for _, keyValue := range strings.Split(prop, "\n") {
 		propKeyValue := strings.Split(keyValue, "=")


### PR DESCRIPTION
…configMap

So if the specified key does not exist... the output will still have the rest of the hierarchy but we'll give out a error message. Earlier it was raising an runtime error

error sample:
```
ERRO[0000] can not find the given key in the configMap applications.properties
```